### PR TITLE
Update Prefabs for ROS 2 Frame Editor Component

### DIFF
--- a/Assets/UR10/UR10.prefab
+++ b/Assets/UR10/UR10.prefab
@@ -98,16 +98,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3162201113938073911
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11215053288689314569,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "flange",
-                        "Joint Name": "wrist_3-flange",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 400995838768749823,
@@ -118,6 +108,15 @@
                             0.000001707547198748216,
                             -90.00000762939453
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11215053288689314569,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "flange",
+                        "Joint Name": "wrist_3-flange",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -296,16 +295,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 14178936275163388283
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6725714804015519141,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "tool0",
-                        "Joint Name": "flange-tool0",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12372534703390537978,
@@ -316,6 +305,15 @@
                             89.99996185302734,
                             0.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6725714804015519141,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "tool0",
+                        "Joint Name": "flange-tool0",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -529,19 +527,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 2900401725638520869
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1337278135579268774,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "forearm_link",
-                        "Joint Name": "elbow_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8412104066248939483,
@@ -557,6 +542,18 @@
                             -9.039679602072037e-29,
                             -1.5166065725475662e-21
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1337278135579268774,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "forearm_link",
+                        "Joint Name": "elbow_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -769,19 +766,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 14891883367921573398
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15791815753167737967,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "wrist_3_link",
-                        "Joint Name": "wrist_3_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3868267867187415994,
@@ -797,6 +781,18 @@
                             -1.3559519403108056e-28,
                             3.791516178933426e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15791815753167737967,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_3_link",
+                        "Joint Name": "wrist_3_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -906,19 +902,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 11110003518163621478
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11750197844762334575,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "shoulder_link",
-                        "Joint Name": "shoulder_pan_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14238198336063306324,
@@ -929,6 +912,18 @@
                             0.0,
                             0.12729999423027039
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11750197844762334575,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "shoulder_link",
+                        "Joint Name": "shoulder_pan_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1130,19 +1125,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4447019963576809044
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11919293354833549866,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "wrist_2_link",
-                        "Joint Name": "wrist_2_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14125838079395442588,
@@ -1158,6 +1140,18 @@
                             -1.5166065725475662e-21,
                             -7.0167078561561656e-15
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11919293354833549866,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_2_link",
+                        "Joint Name": "wrist_2_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1254,19 +1248,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3577927265296436934
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 3643723356448930267,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "base_link_inertia",
-                        "Joint Name": "base_link-base_link_inertia",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 16706756367717092850,
@@ -1277,6 +1258,18 @@
                             0.0,
                             180.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 3643723356448930267,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base_link_inertia",
+                        "Joint Name": "base_link-base_link_inertia",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1326,18 +1319,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4882093382413089942
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2647709708475378771,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "base",
-                        "Joint Name": "base_link-base_fixed_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8282631054892688013,
@@ -1348,6 +1329,17 @@
                             0.0,
                             180.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2647709708475378771,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base",
+                        "Joint Name": "base_link-base_fixed_joint"
                     }
                 }
             }
@@ -1462,19 +1454,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15346349257908877517
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 8821592955977444905,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "wrist_1_link",
-                        "Joint Name": "wrist_1_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8727709477175995643,
@@ -1485,6 +1464,18 @@
                             -4.470348358154297e-8,
                             0.16394098103046417
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 8821592955977444905,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_1_link",
+                        "Joint Name": "wrist_1_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1663,22 +1654,21 @@
                         "Action name": "joint_trajectory_controller/follow_joint_trajectory"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16030547047118712638,
+                    "Parent Entity": "Entity_[2844844128358]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 4167489356847728006,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
                         "Frame Name": "base_link",
                         "Joint Name": "base_joint"
                     }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 16030547047118712638,
-                    "Parent Entity": "Entity_[2844844128358]"
                 }
             }
         },
@@ -1797,19 +1787,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 12870955700656991821
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2428354820031729224,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "upper_arm_link",
-                        "Joint Name": "shoulder_lift_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10121638506472911477,
@@ -1820,6 +1797,18 @@
                             -7.0167078561561656e-15,
                             3.7915164313689154e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2428354820031729224,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "upper_arm_link",
+                        "Joint Name": "shoulder_lift_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1995,16 +1984,6 @@
                         "$type": "GripperActionServerComponent"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9111996756983695701,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "gripper_link",
-                        "Joint Name": "tool0-gripper",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14197983517855441119,
@@ -2029,6 +2008,15 @@
                         "$type": "VacuumGripperComponent",
                         "EffectorCollider": "Entity_[2840549161062]",
                         "EffectorArticulation": "Entity_[2840549161062]"
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9111996756983695701,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "gripper_link",
+                        "Joint Name": "tool0-gripper",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -2080,22 +2068,21 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 9697593403581928237
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15731962174482153453,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 9761504380790994395,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
                         "Frame Name": "world",
                         "Publish Transform": false
                     }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 15731962174482153453,
-                    "Parent Entity": "ContainerEntity"
                 }
             }
         },
@@ -2310,16 +2297,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 534106856007224175
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 16309935774288793114,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "ft_frame",
-                        "Joint Name": "wrist_3_link-ft_frame",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2109512160091696786,
@@ -2330,6 +2307,15 @@
                             -6.392019448087837e-29,
                             -3.1960067147783805e-29
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 16309935774288793114,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "ft_frame",
+                        "Joint Name": "wrist_3_link-ft_frame",
+                        "Publish Transform": false
                     }
                 }
             }

--- a/Assets/UR20/UR20.prefab
+++ b/Assets/UR20/UR20.prefab
@@ -89,22 +89,21 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 690398386269314164
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7361833121527235019,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 5240521757725247983,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
                         "Frame Name": "world",
                         "Publish Transform": false
                     }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 7361833121527235019,
-                    "Parent Entity": "ContainerEntity"
                 }
             }
         },
@@ -376,16 +375,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 14178936275163388283
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6725714804015519141,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "tool0",
-                        "Joint Name": "flange-tool0",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12372534703390537978,
@@ -396,6 +385,15 @@
                             89.99996185302734,
                             0.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6725714804015519141,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "tool0",
+                        "Joint Name": "flange-tool0",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -479,16 +477,6 @@
                         "$type": "GripperActionServerComponent"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9111996756983695701,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "gripper_link",
-                        "Joint Name": "tool0-gripper",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14197983517855441119,
@@ -513,6 +501,15 @@
                         "$type": "VacuumGripperComponent",
                         "EffectorCollider": "Entity_[7277583976930]",
                         "EffectorArticulation": "Entity_[7277583976930]"
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9111996756983695701,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "gripper_link",
+                        "Joint Name": "tool0-gripper",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -632,16 +629,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15782491215964799077
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 3083845678868066117,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "forearm_link",
-                        "Joint Name": "elbow_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8343753668865873521,
@@ -657,6 +644,15 @@
                             -9.039679602072037e-29,
                             -1.5166065725475662e-21
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 3083845678868066117,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "forearm_link",
+                        "Joint Name": "elbow_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -957,16 +953,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7444936094356350361
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11103590891730747664,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wrist_1_link",
-                        "Joint Name": "wrist_1_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2729287346078457237,
@@ -977,6 +963,15 @@
                             -2.9802322387695313e-8,
                             0.20100001990795135
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11103590891730747664,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wrist_1_link",
+                        "Joint Name": "wrist_1_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1085,16 +1080,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3106518939751339603
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 17639613658207484215,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wrist_2_link",
-                        "Joint Name": "wrist_2_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 17677009970489914270,
@@ -1110,6 +1095,15 @@
                             -1.5166065725475662e-21,
                             -7.0167078561561656e-15
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 17639613658207484215,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wrist_2_link",
+                        "Joint Name": "wrist_2_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1229,16 +1223,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 9940279564102040212
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9293043279228032287,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "upper_arm_link",
-                        "Joint Name": "shoulder_lift_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 16759217769144000533,
@@ -1249,6 +1233,15 @@
                             -7.0167078561561656e-15,
                             3.7915164313689154e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9293043279228032287,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "upper_arm_link",
+                        "Joint Name": "shoulder_lift_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1429,16 +1422,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4296747952673902477
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 491013427572720828,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "shoulder_link",
-                        "Joint Name": "shoulder_pan_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 11681556027088341968,
@@ -1454,6 +1437,15 @@
                             0.0,
                             180.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 491013427572720828,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "shoulder_link",
+                        "Joint Name": "shoulder_pan_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1594,16 +1586,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3162201113938073911
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11215053288689314569,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "flange",
-                        "Joint Name": "wrist_3-flange",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 400995838768749823,
@@ -1614,6 +1596,15 @@
                             0.0,
                             -90.00000762939453
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11215053288689314569,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "flange",
+                        "Joint Name": "wrist_3-flange",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1918,18 +1909,17 @@
                         "Action name": "joint_trajectory_controller/follow_joint_trajectory"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 10808114954278001120,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 18356661809412537335,
                     "Parent Entity": "Entity_[1060644049743]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 10808114954278001120,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },
@@ -2049,16 +2039,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 12640989737706851468
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11393412447853053353,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wrist_3_link",
-                        "Joint Name": "wrist_3_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3799957344903901769,
@@ -2074,6 +2054,15 @@
                             -5.649799751295023e-29,
                             3.791516178933426e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11393412447853053353,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wrist_3_link",
+                        "Joint Name": "wrist_3_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -2122,16 +2111,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 534106856007224175
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 16309935774288793114,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "ft_frame",
-                        "Joint Name": "wrist_3_link-ft_frame",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2109512160091696786,
@@ -2147,6 +2126,15 @@
                             -9.588028570278648e-29,
                             2.2696220215697066e-35
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 16309935774288793114,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "ft_frame",
+                        "Joint Name": "wrist_3_link-ft_frame",
+                        "Publish Transform": false
                     }
                 }
             }

--- a/gem.json
+++ b/gem.json
@@ -19,7 +19,7 @@
     ],
     "icon_path": "preview.png",
     "dependencies": [
-        "ROS2",
+        "ROS2==3.0.0",
         "PhysX"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-ur-robots-gem",


### PR DESCRIPTION
Update prefabs to use the ROS2FrameEditorComponent (https://github.com/o3de/o3de-extras/pull/593).