### PR TITLE
fix: version of required PhysX gem

### DIFF
--- a/gem.json
+++ b/gem.json
@@ -20,7 +20,7 @@
     "icon_path": "preview.png",
     "dependencies": [
         "ROS2",
-        "PhysX"
+        "PhysX5"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-ur-robots-gem",
     "restricted": "URRobots"


### PR DESCRIPTION
When this gem is used with o3de (stabilization/2490)[https://github.com/o3de/o3de/tree/stabilization/2409], Editor can't be opened due to segmentaion fault.

This PR changes `PhysX` to `PhysX5` in `gem.json`.

